### PR TITLE
Update LAB_AK_03_Implementing_failover_clustering.md

### DIFF
--- a/Instructions/Labs/LAB_AK_03_Implementing_failover_clustering.md
+++ b/Instructions/Labs/LAB_AK_03_Implementing_failover_clustering.md
@@ -119,15 +119,15 @@ lab:
    Get-Disk
    ```
 
-   > **Note:** Ensure that the three iSCSI disks are listed with the **Offline** operational status. These should be disks with numbers 1, 2, and 3.
+   > **Note:** Ensure that the three iSCSI disks are listed with the **Offline** operational status. These should be disks with numbers 2, 3, and 4.
 
 1. To initialize the disks, at the Windows PowerShell prompt providing access to the local session, enter the following commands, and after entering each command, press Enter:
 
    ```powershell
    Get-Disk | Where OperationalStatus -eq 'Offline' | Initialize-Disk -PartitionStyle MBR
-   New-Partition -DiskNumber 1 -Size 5gb -AssignDriveLetter
    New-Partition -DiskNumber 2 -Size 5gb -AssignDriveLetter
    New-Partition -DiskNumber 3 -Size 5gb -AssignDriveLetter
+   New-Partition -DiskNumber 4 -Size 5gb -AssignDriveLetter
    Format-Volume -DriveLetter E -FileSystem NTFS
    Format-Volume -DriveLetter F -FileSystem NTFS
    Format-Volume -DriveLetter G -FileSystem NTFS


### PR DESCRIPTION
There's an additional disk on the lab VM now and the disks we need to init are shifted by 1.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-