### PR TITLE
Fix Public IP SKU and allocation method L02-rg_template.json

### DIFF
--- a/Allfiles/Labfiles/Lab02/L02-rg_template.json
+++ b/Allfiles/Labfiles/Lab02/L02-rg_template.json
@@ -74,11 +74,11 @@
       "apiVersion": "[variables('networkAPIVersion')]",
       "location": "[resourceGroup().location]",
       "sku": {
-       "name": "Basic"
+       "name": "Standard"
       },
       "properties": {
         "publicIPAddressVersion": "IPv4",
-        "publicIPAllocationMethod": "Dynamic",
+        "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4
       }
     },


### PR DESCRIPTION
# Module/Lab: 02
## Exercise: 3

Fix Public IP SKU and allocation method in L02-rg_template.json.

Changes proposed in this pull request:

- Line 77: "name": "Standard"
- Line 81: "publicIPAllocationMethod": "Static",

### Relevant Issues link

Fixes #69, #71, and #73
