### PR TITLE
Update L02-rg_template.json

### DIFF
--- a/Allfiles/Labfiles/Lab02/L02-rg_template.json
+++ b/Allfiles/Labfiles/Lab02/L02-rg_template.json
@@ -74,11 +74,11 @@
       "apiVersion": "[variables('networkAPIVersion')]",
       "location": "[resourceGroup().location]",
       "sku": {
-       "name": "Basic"
+       "name": "Standard"
       },
       "properties": {
         "publicIPAddressVersion": "IPv4",
-        "publicIPAllocationMethod": "Dynamic",
+        "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4
       }
     },


### PR DESCRIPTION
Standard SKU public IP is deprecated and cannot longer be deployed

# Module/Lab: 02
## Exercise: 03

Fixes #73  .

Changes proposed in this pull request:
update deprecated basic SKU PIP to standard SKU
-
-
-

### Relevant Issues link


